### PR TITLE
Use Function.prototype for extreme minimalism

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,2 @@
-/**
- * No operation.
- * @api public
- */
+// No operation
 module.exports = Function.prototype;


### PR DESCRIPTION
There's just nothing like `Function.prototype` as a noop function
